### PR TITLE
Fix blender version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ https://github.com/ami-iit/blend-my-bot/assets/29798643/c224cd56-1d90-42dd-aec5-
 - [`Blender 3.6`](<https://www.blender.org/download/lts/3-6/>)
 - [`iDynTree`](<https://github.com/robotology/idyntree>)
 - [`numpy`](<https://numpy.org/>)
-- [`bpy`](<https://pypi.org/project/bpy/>)
+- [`bpy 3.6`](<https://pypi.org/project/bpy/>)
 
 Note: This library has been tested with the `appimage` version of Blender 3.6. You should use a Python version that matches the one supported by the Blender version.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://github.com/ami-iit/blend-my-bot/assets/29798643/c224cd56-1d90-42dd-aec5-
 ## 🐍 Requirements
 
 - [`python3`](<https://wiki.python.org/moin/BeginnersGuide>)
-- [`Blender`](<https://www.blender.org/download/>)
+- [`Blender 3.6`](<https://www.blender.org/download/lts/3-6/>)
 - [`iDynTree`](<https://github.com/robotology/idyntree>)
 - [`numpy`](<https://numpy.org/>)
 - [`bpy`](<https://pypi.org/project/bpy/>)

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ python_requires = >=3.10
 install_requires =
         idyntree
         numpy
-        bpy
+        bpy==3.6
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Blender recently updated its version to 4, and the `bpy v.4` API got some changes.
The package is not really tested with this new release: in this PR I fix the supported Blender version to the LTS one, the 3.6. 
I will update the library to Blender 4.0 in a future PR.