### PR TITLE
Skip importing models with no visuals

### DIFF
--- a/src/blend_my_bot/model_importer.py
+++ b/src/blend_my_bot/model_importer.py
@@ -85,6 +85,8 @@ class ModelImporter:
         )
         for link_id in range(model_geometry.getNrOfLinks()):
             link_name = model_geometry.getLinkName(link_id)
+            if visuals[link_id] == ():  # no visual
+                continue
             link_visual = visuals[link_id][0]
             if link_visual.isExternalMesh():
                 mesh_path = (


### PR DESCRIPTION
This PR should handle the case when there is no visual associated to a link. We spotted this case with @FabioBergonti