### PR TITLE
add script to setup conda env and fix stl import

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ Create a conda environment and install the dependencies:
 You can use the `setup_conda_blender.sh` script to create a conda environment having the same python version as the one used by the Blender version you are using. This script will also create a symbolic link to the conda environment in the Blender python folder. Run the script from the root of the repository:
 
 ```bash
-bash setup_conda_blender.sh folder/to/blender/executable
-activate blender_env_version
+conda activate blender_env_version
 pip install blend-my-bot
 # or pip install -e .
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Create a conda environment and install the dependencies:
 You can use the `setup_conda_blender.sh` script to create a conda environment having the same python version as the one used by the Blender version you are using. This script will also create a symbolic link to the conda environment in the Blender python folder. Run the script from the root of the repository:
 
 ```bash
+bash setup_conda_blender.sh folder/to/blender/executable
 conda activate blender_env_version
 pip install blend-my-bot
 # or pip install -e .

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## 🐍 Requirements
 
 - [`python3`](<https://wiki.python.org/moin/BeginnersGuide>)
-- [`Blender 4`](<https://www.blender.org/download/lts/3-6/>)
+- [`Blender 4`](<https://www.blender.org/download/>)
 - [`iDynTree`](<https://github.com/robotology/idyntree>)
 - [`numpy`](<https://numpy.org/>)
 - [`bpy 4`](<https://pypi.org/project/bpy/>)
@@ -26,6 +26,21 @@
 ## 💾 Installation
 
 Create a conda environment and install the dependencies:
+
+### Use the `setup_conda_blender.sh` script
+
+You can use the `setup_conda_blender.sh` script to create a conda environment having the same python version as the one used by the Blender version you are using. This script will also create a symbolic link to the conda environment in the Blender python folder. Run the script from the root of the repository:
+
+```bash
+bash setup_conda_blender.sh folder/to/blender/executable
+activate blender_env_version
+pip install blend-my-bot
+# or pip install -e .
+```
+
+### Manually
+
+If you prefer to do it manually, you can follow these steps:
 
 ```bash
 conda create -n blender_env python=3.10

--- a/setup_conda_blender.sh
+++ b/setup_conda_blender.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Usage: sudo ./blender-conda.sh /usr/share/blender/4.1
+# Usage: sudo ./setup_conda_blender.sh /usr/share/blender/4.1
 # ------------------------------------------------------------------------------
 
 set -euo pipefail

--- a/setup_conda_blender.sh
+++ b/setup_conda_blender.sh
@@ -33,7 +33,7 @@ echo "→ Blender uses Python $BLENDER_PY_VERSION"
 # ──────────────────────────────────────────────────────────────────────────────
 # 2. Create / reuse matching Conda environment
 # ──────────────────────────────────────────────────────────────────────────────
-ENV_NAME="blender_env${BLENDER_PY_VERSION//./}"   # e.g. blender_env311
+ENV_NAME="blender_env_${BLENDER_PY_VERSION//./}"   # e.g. blender_env311
 CONDA_HOME="$(conda info --base)"
 ENV_PATH="$CONDA_HOME/envs/$ENV_NAME"
 

--- a/setup_conda_blender.sh
+++ b/setup_conda_blender.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Usage: sudo ./blender-conda.sh /usr/share/blender/4.1
+# ------------------------------------------------------------------------------
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <BLENDER_ROOT>"
+  exit 1
+fi
+
+BLENDER_ROOT="$(realpath "$1")"
+PYTHON_DIR="$BLENDER_ROOT/python"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 1. Locate Blender’s bundled Python binary, whatever it’s called
+# ──────────────────────────────────────────────────────────────────────────────
+BLENDER_PY_BIN="$(find "$PYTHON_DIR/bin" -maxdepth 1 -type f -executable -name 'python3*' | head -n1 || true)"
+
+if [[ -z "$BLENDER_PY_BIN" ]]; then
+  echo "❌  Cannot find Blender's bundled Python inside: $PYTHON_DIR/bin/" >&2
+  exit 1
+fi
+
+# Pull out the major.minor version (e.g. 3.11)
+BLENDER_PY_VERSION="$("$BLENDER_PY_BIN" - <<'PY'
+import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")
+PY
+)"
+echo "→ Blender uses Python $BLENDER_PY_VERSION"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 2. Create / reuse matching Conda environment
+# ──────────────────────────────────────────────────────────────────────────────
+ENV_NAME="blender_env${BLENDER_PY_VERSION//./}"   # e.g. blender_env311
+CONDA_HOME="$(conda info --base)"
+ENV_PATH="$CONDA_HOME/envs/$ENV_NAME"
+
+if conda env list | grep -qE "^$ENV_NAME\s"; then
+  echo "✓ Conda env '$ENV_NAME' already exists"
+else
+  echo "→ Creating Conda env '$ENV_NAME' with python=$BLENDER_PY_VERSION"
+  conda create -y -n "$ENV_NAME" python="$BLENDER_PY_VERSION"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 3. Swap Blender’s python/ with a symlink to the env
+# ──────────────────────────────────────────────────────────────────────────────
+cd "$BLENDER_ROOT"
+
+if [[ ! -L python ]]; then
+  TS=$(date +%s)
+  sudo mv python "python.bak.$TS"
+  echo "→ Backed up original python/ to python.bak.$TS"
+fi
+
+sudo ln -sfn "$ENV_PATH" python   # -f/-n: replace if link already exists
+echo "✓ Linked $ENV_PATH  →  $BLENDER_ROOT/python"
+
+echo
+echo "All set!  Launch Blender and run in the console:"
+echo "    import sys, numpy, pandas, bpy"
+echo "    print(sys.executable)"
+echo
+echo "to verify that it's using your new Conda environment."

--- a/src/blend_my_bot/model_importer.py
+++ b/src/blend_my_bot/model_importer.py
@@ -104,7 +104,7 @@ class ModelImporter:
                     mesh = bpy.context.selected_objects[0]
                 elif mesh_path.endswith(".stl"):
                     print(f"Importing {mesh_path}")
-                    bpy.ops.import_mesh.stl(filepath=mesh_path)
+                    bpy.ops.wm.stl_import(filepath=mesh_path)
                     mesh = bpy.context.selected_objects[0]
                 else:
                     raise ValueError(


### PR DESCRIPTION
This pull request introduces a more streamlined and user-friendly process for setting up the required Python environment to work with Blender and this project. The main improvements include a new setup script for Conda environments, updated documentation to reflect this change, and a minor fix to the STL import method in the codebase.

**Environment setup improvements:**

* Added a new `setup_conda_blender.sh` script that automatically creates a Conda environment matching Blender's Python version and links it to Blender's `python` directory, simplifying the setup process.
* Updated the `README.md` to recommend using the new setup script and clarified the Blender download link. Manual setup instructions are now included as an alternative. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30-R44)

**Codebase fixes:**

* Changed the STL import call in `src/blend_my_bot/model_importer.py` from `bpy.ops.import_mesh.stl` to `bpy.ops.wm.stl_import`, ensuring compatibility with the current Blender API.